### PR TITLE
Usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Taro Ad Fields
 
 Tags: advertisement  
-Contributors: tarosky, Takahashi_Fumiki, yocchi161  
+Contributors: tarosky, Takahashi_Fumiki, yocchi161, tswallie  
 Tested up to: 6.8  
 Stable tag: nightly  
 License: GPLv3 or later  

--- a/includes/context.php
+++ b/includes/context.php
@@ -249,7 +249,7 @@ add_action('edited_ad-position', function ( $term_id ) {
 	$valid_slugs = [];
 	foreach ( $slugs as $slug ) {
 		$term = get_term_by( 'slug', $slug, 'ad-context' );
-		if ( $term && $term->parent == 0 ) {
+		if ( $term && 0 == $term->parent ) {
 			$valid_slugs[] = $slug;
 		}
 	}

--- a/includes/context.php
+++ b/includes/context.php
@@ -188,3 +188,75 @@ function taf_register_contexts() {
 	}
 	return $registered;
 }
+
+/**
+ * Add term meta which indicates this position is for iframe.
+ *
+ */
+add_action( 'ad-position_edit_form_fields', function ( WP_Term $tag ) {
+	$saved_slugs = get_term_meta($tag->term_id, 'taf_contexts', false);
+    if (!is_array($saved_slugs)) $saved_slugs = [];
+
+	$terms = get_terms([
+        'taxonomy'   => 'ad-context',
+        'hide_empty' => false,
+        'parent'     => 0,
+    ]);
+
+	?>
+	<tr>
+		<th>
+			<label for="taf-term-context">
+				<?php esc_html_e( 'Required Contexts', 'taf' ); ?>
+			</label>
+		</th>
+		<td>
+			<?php foreach ( $terms as $term ) : ?>
+				<label style="display: inline-block; margin: 0 10px 10px 0;">
+					<input type="checkbox"
+						   name="taf-term-context[]"
+						   value="<?php echo esc_attr( $term->slug ); ?>"
+						<?php checked( in_array( $term->slug, $saved_slugs, true ) ); ?>
+					/>
+					<?php echo esc_html( $term->name ); ?>
+				</label>
+			<?php endforeach; ?>
+			<p class="description">
+				<?php esc_html_e( 'Select context categories (parents) that should be required for this position.', 'taf' ); ?>
+			</p>
+		</td>
+	</tr>
+	<?php
+}, 12 );
+
+// Save contexts termmeta
+add_action('edited_ad-position', function ($term_id) {
+	if (!isset($_POST['taf-term-context']) || !is_array($_POST['taf-term-context'])) {
+		return;
+    }
+	
+	// Skip if not the term being edited in UI
+    if (isset($_GET['tag_ID']) && intval($_GET['tag_ID']) !== intval($term_id)) {
+		return;
+    }
+
+    // Sanitize each value in the array.
+    $slugs = array_map('sanitize_text_field', $_POST['taf-term-context']);
+
+	// Make sure each slug is valid.
+    $valid_slugs = [];
+    foreach ($slugs as $slug) {
+        $term = get_term_by('slug', $slug, 'ad-context');
+        if ($term && $term->parent == 0) {
+            $valid_slugs[] = $slug;
+        }
+    }
+
+    // Delete existing values for this meta key.
+	delete_term_meta($term_id, 'taf_contexts');
+
+	// Save each each value to database.
+	foreach ($valid_slugs as $slug) {
+		add_term_meta($term_id, 'taf_contexts', $slug, false);
+	}
+});

--- a/includes/context.php
+++ b/includes/context.php
@@ -75,7 +75,7 @@ function taf_context_meta_box_callback( $post ) {
 			printf( '<p class="description">%s</p>', nl2br( esc_html( $parent->description ) ) );
 		}
 		// Allow selecting no context by adding a hidden input field.
-		echo '<input type="hidden" name="tax_input[ad-context][]" value="" />';
+		printf( '<input type="hidden" name="tax_input[ad-context][]" value="%s" />', esc_attr( '' ) );
 		foreach ( $children as $child ) {
 			printf(
 				'<p class="ad-context__item"><label><input type="checkbox" name="tax_input[%s][]" value="%d" %s /> %s</label></p>',

--- a/includes/context.php
+++ b/includes/context.php
@@ -109,7 +109,7 @@ add_action( 'admin_notices', function () {
 		<div class="notice notice-info">
 			<p>
 				<strong><?php esc_html_e( 'Notice:', 'taf' ); ?></strong>
-				<?php esc_html_e( 'Default contexts are registered from theme or plugin. Changing them may cause unexpected result.', 'taf' ); ?>
+				<?php esc_html_e( 'Default contexts are registered from theme or plugin. Changing their slug may cause unexpected result.', 'taf' ); ?>
 			</p>
 		</div>
 		<?php

--- a/includes/context.php
+++ b/includes/context.php
@@ -194,14 +194,16 @@ function taf_register_contexts() {
  *
  */
 add_action( 'ad-position_edit_form_fields', function ( WP_Term $tag ) {
-	$saved_slugs = get_term_meta($tag->term_id, 'taf_contexts', false);
-    if (!is_array($saved_slugs)) $saved_slugs = [];
+	$saved_slugs = get_term_meta( $tag->term_id, 'taf_contexts', false );
+	if ( ! is_array( $saved_slugs ) ) {
+		$saved_slugs = [];
+	}
 
 	$terms = get_terms([
-        'taxonomy'   => 'ad-context',
-        'hide_empty' => false,
-        'parent'     => 0,
-    ]);
+		'taxonomy'   => 'ad-context',
+		'hide_empty' => false,
+		'parent'     => 0,
+	]);
 
 	?>
 	<tr>
@@ -214,8 +216,8 @@ add_action( 'ad-position_edit_form_fields', function ( WP_Term $tag ) {
 			<?php foreach ( $terms as $term ) : ?>
 				<label style="display: inline-block; margin: 0 10px 10px 0;">
 					<input type="checkbox"
-						   name="taf-term-context[]"
-						   value="<?php echo esc_attr( $term->slug ); ?>"
+							name="taf-term-context[]"
+							value="<?php echo esc_attr( $term->slug ); ?>"
 						<?php checked( in_array( $term->slug, $saved_slugs, true ) ); ?>
 					/>
 					<?php echo esc_html( $term->name ); ?>
@@ -230,33 +232,33 @@ add_action( 'ad-position_edit_form_fields', function ( WP_Term $tag ) {
 }, 12 );
 
 // Save contexts termmeta
-add_action('edited_ad-position', function ($term_id) {
-	if (!isset($_POST['taf-term-context']) || !is_array($_POST['taf-term-context'])) {
+add_action('edited_ad-position', function ( $term_id ) {
+	if ( ! isset( $_POST['taf-term-context'] ) || ! is_array( $_POST['taf-term-context'] ) ) {
 		return;
-    }
-	
-	// Skip if not the term being edited in UI
-    if (isset($_GET['tag_ID']) && intval($_GET['tag_ID']) !== intval($term_id)) {
-		return;
-    }
+	}
 
-    // Sanitize each value in the array.
-    $slugs = array_map('sanitize_text_field', $_POST['taf-term-context']);
+	// Skip if not the term being edited in UI
+	if ( isset( $_GET['tag_ID'] ) && intval( $_GET['tag_ID'] ) !== intval( $term_id ) ) {
+		return;
+	}
+
+	// Sanitize each value in the array.
+	$slugs = array_map( 'sanitize_text_field', $_POST['taf-term-context'] );
 
 	// Make sure each slug is valid.
-    $valid_slugs = [];
-    foreach ($slugs as $slug) {
-        $term = get_term_by('slug', $slug, 'ad-context');
-        if ($term && $term->parent == 0) {
-            $valid_slugs[] = $slug;
-        }
-    }
+	$valid_slugs = [];
+	foreach ( $slugs as $slug ) {
+		$term = get_term_by( 'slug', $slug, 'ad-context' );
+		if ( $term && $term->parent == 0 ) {
+			$valid_slugs[] = $slug;
+		}
+	}
 
-    // Delete existing values for this meta key.
-	delete_term_meta($term_id, 'taf_contexts');
+	// Delete existing values for this meta key.
+	delete_term_meta( $term_id, 'taf_contexts' );
 
 	// Save each each value to database.
-	foreach ($valid_slugs as $slug) {
-		add_term_meta($term_id, 'taf_contexts', $slug, false);
+	foreach ( $valid_slugs as $slug ) {
+		add_term_meta( $term_id, 'taf_contexts', $slug, false );
 	}
 });

--- a/includes/context.php
+++ b/includes/context.php
@@ -75,7 +75,7 @@ function taf_context_meta_box_callback( $post ) {
 			printf( '<p class="description">%s</p>', nl2br( esc_html( $parent->description ) ) );
 		}
 		// Allow selecting no context by adding a hidden input field.
-		echo '<input type="hidden" name="tax_input[ad-context][]" value="empty" />';
+		echo '<input type="hidden" name="tax_input[ad-context][]" value="" />';
 		foreach ( $children as $child ) {
 			printf(
 				'<p class="ad-context__item"><label><input type="checkbox" name="tax_input[%s][]" value="%d" %s /> %s</label></p>',

--- a/includes/context.php
+++ b/includes/context.php
@@ -249,7 +249,7 @@ add_action('edited_ad-position', function ( $term_id ) {
 	$valid_slugs = [];
 	foreach ( $slugs as $slug ) {
 		$term = get_term_by( 'slug', $slug, 'ad-context' );
-		if ( $term && 0 == $term->parent ) {
+		if ( $term && 0 === $term->parent ) {
 			$valid_slugs[] = $slug;
 		}
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -310,62 +310,71 @@ function taf_iframe_url( $position, $args = array(), $field = 'slug' ) {
  * Validates that all context requirements for each ad position are satisfied.
  *
  * For each position's required contexts (stored as term meta),
- * the function checks whether at least one of the submitted context ids
+ * the function checks whether at least one of the post's context ids
  * in ad-content has a parent context that matches.
  *
- * @param array $tax_input Array of taxonomy inputs
- * @return bool True if a match was found for all the required contexts.
+ * @param null|int|WP_Post $post Post Object or Post ID
+ * @return WP_Error|true True if a match was found for all the required contexts.
  */
-function taf_validate_tax_input( $tax_input ) {
+function taf_validate_ad_taxonomies( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post ) {
+		return new WP_Error( 'invalid_post', __( 'Invalid post object or ID', 'taf' ) );
+	}
 
-	// Get ad context (array of term ids)
-	$ad_context = array_filter( $tax_input['ad-context'] ?? [], 'is_numeric' );
+	$errors = new WP_Error();
 
-	// Get ad position (array of term names)
-	$ad_position = array_filter(
-		array_map( 'trim', explode( ',', $tax_input['ad-position'] ?? '' ) ),
-		fn( $val ) => '' !== $val
-	);
+	$context_ids = wp_get_post_terms( $post->ID, 'ad-context', [ 'fields' => 'ids' ] );
+	$positions   = wp_get_post_terms( $post->ID, 'ad-position', [ 'fields' => 'names' ] );
 
 	// Go through every position's required contexts and look for a match.
-	foreach ( $ad_position as $pos ) {
+	foreach ( $positions as $pos ) {
 		$pos_term = get_term_by( 'name', $pos, 'ad-position' );
+		if ( ! $pos_term && is_wp_error( $pos_term ) ) {
+			continue;
+		}
 
-		if ( $pos_term && ! is_wp_error( $pos_term ) ) {
-			$req_context_slugs = get_term_meta( $pos_term->term_id, 'taf_contexts', false );
+		// Skip if position has no required contexts.
+		$req_context_slugs = get_term_meta( $pos_term->term_id, 'taf_contexts', false );
+		if ( empty( $req_context_slugs ) ) {
+			continue;
+		}
 
-			// Skip if position has no required contexts.
-			if ( empty( $req_context_slugs ) ) {
-				continue;
-			}
+		// Make sure each required context matches with the parent of at least one of the post's contexts in ad-context.
+		foreach ( $req_context_slugs as $slug ) {
+			$matched = false;
 
-			// Make sure each required context matches with the parent of at least one of the submitted contexts in ad-context.
-			foreach ( $req_context_slugs as $slug ) {
-				$matched = false;
+			foreach ( $context_ids as $context_id ) {
+				$context_term = get_term( $context_id, 'ad-context' );
 
-				foreach ( $ad_context as $context_id ) {
-					$context_term = get_term( $context_id, 'ad-context' );
+				if ( $context_term && ! is_wp_error( $context_term ) && $context_term->parent > 0 ) {
+					$parent_term = get_term( $context_term->parent, 'ad-context' );
 
-					if ( $context_term && ! is_wp_error( $context_term ) && $context_term->parent > 0 ) {
-						$parent_term = get_term( $context_term->parent, 'ad-context' );
-
-						// If match found, skip to next required context.
-						if ( $parent_term && ! is_wp_error( $parent_term ) ) {
-							if ( $parent_term->slug === $slug ) {
-								$matched = true;
-								break;
-							}
-						}
+					// If match found, skip to next required context.
+					if ( $parent_term && ! is_wp_error( $parent_term ) && $parent_term->slug === $slug ) {
+						$matched = true;
+						break;
 					}
 				}
+			}
 
-				// Return false if no matching context was found.
-				if ( ! $matched ) {
-					return false;
-				}
+			// Add error if no matching context was found.
+			if ( ! $matched ) {
+				$term             = get_term_by( 'slug', $slug, 'ad-context' );
+				$req_context_name = $term && ! is_wp_error( $term ) ? $term->name : $slug;
+
+				$errors->add(
+					'missing_context',
+					sprintf(
+						/* translators: 1: position name, 2: required context name */
+						__( 'The position "%1$s" requires you to set a context for "%2$s".', 'taf' ),
+						$pos,
+						$req_context_name
+					)
+				);
 			}
 		}
 	}
 
-	return true;
+	return $errors->has_errors() ? $errors : true;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -324,7 +324,7 @@ function taf_validate_tax_input( $tax_input ) {
 	// Get ad position (array of term names)
 	$ad_position = array_filter(
 		array_map( 'trim', explode( ',', $tax_input['ad-position'] ?? '' ) ),
-		fn( $val ) => $val !== ''
+		fn( $val ) => '' !== $val
 	);
 
 	// Go through every position's required contexts and look for a match.

--- a/includes/meta-box.php
+++ b/includes/meta-box.php
@@ -71,7 +71,7 @@ add_action( 'save_post', function ( $post_id, $post ) {
 add_action( 'admin_notices', function () {
 	$screen = get_current_screen();
 
-	if ( isset( $screen->post_type ) && $screen->post_type === 'ad-content' && $screen->base === 'post' ) {
+	if ( isset( $screen->post_type ) && 'ad-content' === $screen->post_type && 'post' === $screen->base ) {
 		$post_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
 		if ( ! $post_id ) {
 			return;

--- a/includes/meta-box.php
+++ b/includes/meta-box.php
@@ -47,6 +47,13 @@ JS;
 	<?php
 }, 11 );
 
+// Filter ad-context on submit
+add_action('save_post', function () {
+	if ( isset( $_POST['tax_input']['ad-context'] ) && is_array( $_POST['tax_input']['ad-context'] ) ) {
+		$_POST['tax_input']['ad-context'] = array_filter( $_POST['tax_input']['ad-context'], 'is_numeric' );
+	}
+}, 9);
+
 // Save custom field
 add_action( 'save_post', function ( $post_id, $post ) {
 	if ( wp_is_post_autosave( $post ) || wp_is_post_revision( $post ) ) {

--- a/includes/meta-box.php
+++ b/includes/meta-box.php
@@ -47,13 +47,6 @@ JS;
 	<?php
 }, 11 );
 
-// Filter ad-context on submit
-add_action('save_post', function () {
-	if ( isset( $_POST['tax_input']['ad-context'] ) && is_array( $_POST['tax_input']['ad-context'] ) ) {
-		$_POST['tax_input']['ad-context'] = array_filter( $_POST['tax_input']['ad-context'], 'is_numeric' );
-	}
-}, 9);
-
 // Save custom field
 add_action( 'save_post', function ( $post_id, $post ) {
 	if ( wp_is_post_autosave( $post ) || wp_is_post_revision( $post ) ) {

--- a/includes/post_type.php
+++ b/includes/post_type.php
@@ -79,7 +79,7 @@ add_action( 'init', function () {
 								// check if Position exists that requires Context and is checked.
 								$('.adPosition__item').each(function () {
 									if (
-										$(this).find('.button').toArray().some(el => $(el).text().trim() === $parent) &&
+										$(this).find('.button').filter((_, el) => $(el).text().trim() === $parent).length > 0 &&
 										$(this).find('.adPosition__check').is(':checked')
 									){
 										found = true;

--- a/includes/post_type.php
+++ b/includes/post_type.php
@@ -130,7 +130,7 @@ add_action( 'init', function () {
 								if ( ! empty( $contexts ) && ! is_wp_error( $contexts ) ) {
 									?>
 									<p>
-										<?php esc_html_e( 'Available Contexts:', 'taf' ); ?>
+										<?php esc_html_e( 'Required Contexts:', 'taf' ); ?>
 										<?php
 										foreach ( $contexts as $context ) {
 											?>

--- a/includes/post_type.php
+++ b/includes/post_type.php
@@ -78,7 +78,10 @@ add_action( 'init', function () {
 
 								// check if Position exists that requires Context and is checked.
 								$('.adPosition__item').each(function () {
-									if ($(this).find('.button').text().trim() === $parent && $(this).find('.adPosition__check').is(':checked')) {
+									if (
+										$(this).find('.button').toArray().some(el => $(el).text().trim() === $parent) &&
+										$(this).find('.adPosition__check').is(':checked')
+									){
 										found = true;
 										return false;
 									}

--- a/includes/post_type.php
+++ b/includes/post_type.php
@@ -169,7 +169,7 @@ add_action( 'admin_notices', function () {
 		<div class="notice notice-info">
 			<p>
 				<strong><?php esc_html_e( 'Notice:', 'taf' ); ?></strong>
-				<?php esc_html_e( 'Default positions are registered from theme or plugin. Changing them may cause unexpected result.', 'taf' ); ?>
+				<?php esc_html_e( 'Default positions are registered from theme or plugin. Changing their slug may cause unexpected result.', 'taf' ); ?>
 			</p>
 		</div>
 		<?php


### PR DESCRIPTION
- 各広告ポジションのコンテキスト要件がすべて満たされていない場合、送信時に通知を表示するようにしました。
- エディタのバグを修正：複数のコンテキストを必要とするポジションで、コンテキストが表示されない問題を解決しました。
- `$_POST['tax_input']['ad-context']` に含まれる数値以外の値をフィルタリングする処理を追加しました。

<img width="1710" alt="taro-ad-fields-context-notice" src="https://github.com/user-attachments/assets/680aa361-1f1f-45d2-9e0d-650b1bc487d5" />

この通知は `add_action( 'save_post', function ( $post_id, $post ) {` 内で `set_transient()` を使って表示され、`tax_input` の検証は `taf_validate_tax_input()` によって行われます。

```
/**
 * 各広告ポジションのコンテキスト要件がすべて満たされているかを検証します。
 *
 * 各ポジションに必要なコンテキスト（タームメタとして保存されている）について、
 * 送信された ad-content のコンテキストIDのうち少なくとも1つが
 * 親コンテキストとして一致しているかを確認します。
 *
 * @param array $tax_input タクソノミーの入力配列
 * @return bool すべての必須コンテキストに一致するものがあれば true を返します。
 */
function taf_validate_tax_input( $tax_input ) {
   ...
}
```

上記の画像のように、あるポジションに複数の "Available Contexts"（例: "Body Open"）が設定されている場合にバグが発生することを確認しました。このバグは、JavaScript が各ポジションに対して1つのコンテキストのみを想定していたために起こり、複数のコンテキストがあると比較処理が壊れてしまっていました。

以前は、`$_POST['tax_input']['ad-context']` の値が `[3, 16, 'empty', 27, 4, 'empty']` のようになることがありました。これによって問題が発生したことは今のところありませんが、安全性を考慮してこれらの値をフィルタリングし、hidden input の値を "empty" ではなく空文字 "" に変更することにしました。