### PR TITLE
Dependabot設定を taro-series のグループ化版に統一

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,42 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-    - package-ecosystem: "composer"
-      directory: "/"
-      schedule:
-          interval: "monthly"
-    - package-ecosystem: "npm"
-      directory: "/"
-      schedule:
-          interval: "monthly"
+  # ビルド/開発ツール（npm）
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-type: "direct"   # 推移的依存の単体PRを止める（脆弱性は下の security グループで拾う）
+    groups:
+      # 通常のバージョン更新は major も含めて1本にまとめる（個別PRの乱立を防ぐ）
+      npm-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "major", "minor", "patch" ]
+      # 脆弱性修正（推移的依存含む）もまとめて1本に
+      npm-security:
+        applies-to: security-updates
+        patterns: [ "*" ]
+
+  # 本番依存（composer / vendorに同梱される側）
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-type: "direct"
+    groups:
+      composer-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "major", "minor", "patch" ]
+      composer-security:
+        applies-to: security-updates
+        patterns: [ "*" ]


### PR DESCRIPTION
taro-series のグループ化 dependabot.yml を導入（npm/composer をそれぞれ1本のPRに集約、security グループ、cooldown 7日、direct限定、PR上限5、Asia/Tokyo）。個別 dependabot PR の乱立を防ぐ。（cookie-tasting / taro-ad-fields は既存設定を置換）

🤖 Generated with [Claude Code](https://claude.com/claude-code)