### PR TITLE
Tested up to を 7.0 に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tags: advertisement  
 Contributors: tarosky, Takahashi_Fumiki, yocchi161, tswallie  
-Tested up to: 6.8  
+Tested up to: 7.0  
 Stable tag: nightly  
 License: GPLv3 or later  
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt


### PR DESCRIPTION
Closes #68

## 内容

`README.md` の `Tested up to` を `6.8` から `7.0` に更新します。1行のみの変更です。

## 根拠

WordPress 7.0.2 / PHP 8.3.33 の環境（このリポジトリの `.wp-env.json`）で検証し、このプラグインに起因する問題は見つかりませんでした。検証の詳細は #68 のコメントに記載しています。

| 確認項目 | 結果 |
|---|---|
| PHPUnit | 2 tests / 8 assertions すべて通過 |
| PHP 8.3 での構文チェック（全ファイル） | エラーなし |
| 非推奨関数の使用 | 0件（WordPress 本体の非推奨関数 242 個と照合） |
| `debug.log`（管理画面6画面 + フロント3ページ巡回後） | 出力なし |
| 主要機能（投稿タイプ・ポジション登録・描画・iframe・ウィジェット） | 正常 |

## 補足

- 現在このプラグインのページには「直近3メジャーリリースで未テスト」の警告が出ています。この変更で解消される想定です（WordPress.org は `7.0` をそのブランチの最新パッチに解決するため、`7.0.2` と書く必要はありません）
- 検証はコードの実行とページ取得によるもので、エディタ上の操作（メタボックスの保存、ウィジェットのドラッグ&ドロップ等）は確認範囲外です
- 反映にはリリースの公開が必要です